### PR TITLE
Remove /api prefix in API

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -6,8 +6,8 @@ from app.api import account, budget, price, reservation, root, usage
 
 router = APIRouter()
 router.include_router(root.router)
-router.include_router(account.router, prefix="/api/account", tags=["account"])
-router.include_router(budget.router, prefix="/api/budget", tags=["budget"])
-router.include_router(price.router, prefix="/api/price", tags=["price"])
-router.include_router(reservation.router, prefix="/api/reservation", tags=["reservation"])
-router.include_router(usage.router, prefix="/api/usage", tags=["usage"])
+router.include_router(account.router, prefix="/account", tags=["account"])
+router.include_router(budget.router, prefix="/budget", tags=["budget"])
+router.include_router(price.router, prefix="/price", tags=["price"])
+router.include_router(reservation.router, prefix="/reservation", tags=["reservation"])
+router.include_router(usage.router, prefix="/usage", tags=["usage"])

--- a/tests/api/test_account.py
+++ b/tests/api/test_account.py
@@ -3,7 +3,7 @@ from tests.constants import PROJ_ID, SYS_ID, VLAB_ID
 
 async def test_post_account(api_client):
     response = await api_client.post(
-        "/api/account/system",
+        "/account/system",
         json={"id": SYS_ID, "name": ""},
     )
 
@@ -11,7 +11,7 @@ async def test_post_account(api_client):
     assert response.status_code == 201
 
     response = await api_client.post(
-        "/api/account/virtual-lab",
+        "/account/virtual-lab",
         json={"id": VLAB_ID, "name": "vlab-01"},
     )
 
@@ -19,7 +19,7 @@ async def test_post_account(api_client):
     assert response.status_code == 201
 
     response = await api_client.post(
-        "/api/account/project",
+        "/account/project",
         json={"id": PROJ_ID, "name": "vlab-01/proj-01", "vlab_id": VLAB_ID},
     )
 

--- a/tests/api/test_budget.py
+++ b/tests/api/test_budget.py
@@ -6,7 +6,7 @@ from tests.constants import PROJ_ID, PROJ_ID_2, VLAB_ID
 @pytest.mark.usefixtures("_db_account")
 async def test_budget(api_client):
     response = await api_client.post(
-        "/api/budget/top-up",
+        "/budget/top-up",
         json={"vlab_id": VLAB_ID, "amount": "123.45"},
     )
 
@@ -14,7 +14,7 @@ async def test_budget(api_client):
     assert response.status_code == 200
 
     response = await api_client.post(
-        "/api/budget/assign",
+        "/budget/assign",
         json={"vlab_id": VLAB_ID, "proj_id": PROJ_ID, "amount": "23.45"},
     )
 
@@ -22,7 +22,7 @@ async def test_budget(api_client):
     assert response.status_code == 200
 
     response = await api_client.post(
-        "/api/budget/reverse",
+        "/budget/reverse",
         json={"vlab_id": VLAB_ID, "proj_id": PROJ_ID, "amount": "3.45"},
     )
 
@@ -30,7 +30,7 @@ async def test_budget(api_client):
     assert response.status_code == 200
 
     response = await api_client.post(
-        "/api/budget/move",
+        "/budget/move",
         json={
             "vlab_id": VLAB_ID,
             "debited_from": PROJ_ID,

--- a/tests/api/test_price.py
+++ b/tests/api/test_price.py
@@ -15,7 +15,7 @@ async def test_post_price(api_client):
         "multiplier": "0.00001",
         "vlab_id": None,
     }
-    response = await api_client.post("/api/price", json=data)
+    response = await api_client.post("/price", json=data)
 
     assert response.json() == data | {"id": 1}
     assert response.status_code == 201
@@ -32,7 +32,7 @@ async def test_post_price_with_vlab_and_valid_to(api_client):
         "multiplier": "0.00001",
         "vlab_id": VLAB_ID,
     }
-    response = await api_client.post("/api/price", json=data)
+    response = await api_client.post("/price", json=data)
 
     assert response.json() == data | {"id": 1}
     assert response.status_code == 201
@@ -49,7 +49,7 @@ async def test_post_price_with_proj_instead_of_vlab(api_client):
         "multiplier": "0.00001",
         "vlab_id": PROJ_ID,
     }
-    response = await api_client.post("/api/price", json=data)
+    response = await api_client.post("/price", json=data)
 
     assert response.status_code == 404
 
@@ -64,7 +64,7 @@ async def test_post_price_with_invalid_valid_to(api_client):
         "multiplier": "0.00001",
         "vlab_id": None,
     }
-    response = await api_client.post("/api/price", json=data)
+    response = await api_client.post("/price", json=data)
 
     assert response.status_code == 422
 
@@ -79,6 +79,6 @@ async def test_post_price_with_invalid_costs(api_client):
         "multiplier": "-0.00001",
         "vlab_id": None,
     }
-    response = await api_client.post("/api/price", json=data)
+    response = await api_client.post("/price", json=data)
 
     assert response.status_code == 422

--- a/tests/api/test_reservation.py
+++ b/tests/api/test_reservation.py
@@ -14,7 +14,7 @@ async def test_make_oneshot_reservation(api_client, mock_uuid):
         "subtype": ServiceSubtype.ML_LLM,
         "count": "1000000",
     }
-    response = await api_client.post("/api/reservation/oneshot", json=request_payload)
+    response = await api_client.post("/reservation/oneshot", json=request_payload)
 
     assert response.json() == {
         "job_id": "00000000-0000-0000-0000-000000000001",
@@ -31,7 +31,7 @@ async def test_make_oneshot_reservation(api_client, mock_uuid):
         "subtype": ServiceSubtype.ML_LLM,
         "count": "40000000",
     }
-    response = await api_client.post("/api/reservation/oneshot", json=request_payload)
+    response = await api_client.post("/reservation/oneshot", json=request_payload)
 
     assert response.json() == {
         "error_code": "INSUFFICIENT_FUNDS",
@@ -53,7 +53,7 @@ async def test_make_longrun_reservation(api_client, mock_uuid):
         "instance_type": "",
         "duration": "3600",
     }
-    response = await api_client.post("/api/reservation/longrun", json=request_payload)
+    response = await api_client.post("/reservation/longrun", json=request_payload)
 
     assert response.json() == {
         "job_id": "00000000-0000-0000-0000-000000000001",
@@ -72,7 +72,7 @@ async def test_make_longrun_reservation(api_client, mock_uuid):
         "instance_type": "",
         "duration": "3600",
     }
-    response = await api_client.post("/api/reservation/longrun", json=request_payload)
+    response = await api_client.post("/reservation/longrun", json=request_payload)
 
     assert response.json() == {
         "error_code": "INSUFFICIENT_FUNDS",

--- a/tests/api/test_usage.py
+++ b/tests/api/test_usage.py
@@ -27,7 +27,7 @@ async def test_add_oneshot_usage(api_client, mock_sqs_manager):
         "count": "1000000",
         "timestamp": timestamp,
     }
-    response = await api_client.post("/api/usage/oneshot", json=request_payload)
+    response = await api_client.post("/usage/oneshot", json=request_payload)
 
     assert response.json() == {}
     assert response.status_code == 201
@@ -46,7 +46,7 @@ async def test_add_longrun_usage(api_client, mock_sqs_manager):
         "status": "started",
         "timestamp": timestamp,
     }
-    response = await api_client.post("/api/usage/longrun", json=request_payload)
+    response = await api_client.post("/usage/longrun", json=request_payload)
 
     assert response.json() == {}
     assert response.status_code == 201
@@ -62,7 +62,7 @@ async def test_add_storage_usage(api_client, mock_sqs_manager):
         "size": "1024",
         "timestamp": timestamp,
     }
-    response = await api_client.post("/api/usage/storage", json=request_payload)
+    response = await api_client.post("/usage/storage", json=request_payload)
 
     assert response.json() == {}
     assert response.status_code == 201


### PR DESCRIPTION
Remove /api prefix in API because redundant when the full url is built.