### PR TITLE
Add balance endpoint

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -2,11 +2,12 @@
 
 from fastapi import APIRouter
 
-from app.api import account, budget, price, reservation, root, usage
+from app.api import account, balance, budget, price, reservation, root, usage
 
 router = APIRouter()
 router.include_router(root.router)
 router.include_router(account.router, prefix="/account", tags=["account"])
+router.include_router(balance.router, prefix="/balance", tags=["balance"])
 router.include_router(budget.router, prefix="/budget", tags=["budget"])
 router.include_router(price.router, prefix="/price", tags=["price"])
 router.include_router(reservation.router, prefix="/reservation", tags=["reservation"])

--- a/app/api/balance.py
+++ b/app/api/balance.py
@@ -1,0 +1,47 @@
+"""Balance api."""
+
+from uuid import UUID
+
+from fastapi import APIRouter
+
+from app.dependencies import RepoGroupDep
+from app.schema.api import ApiResponse, ProjBalanceOut, SysBalanceOut, VlabBalanceOut
+from app.service import balance as balance_service
+
+router = APIRouter()
+
+
+@router.get("/system")
+async def get_balance_for_system(repos: RepoGroupDep) -> ApiResponse[SysBalanceOut]:
+    """Return the balance for thr system."""
+    result = await balance_service.get_balance_for_system(repos)
+    return ApiResponse(
+        message="Balance for system",
+        data=result,
+    )
+
+
+@router.get("/virtual-lab/{vlab_id}", response_model_exclude_defaults=True)
+async def get_balance_for_virtual_lab(
+    repos: RepoGroupDep, *, vlab_id: UUID, include_projects: bool = False
+) -> ApiResponse[VlabBalanceOut]:
+    """Return the balance for a given virtual-lab."""
+    result = await balance_service.get_balance_for_vlab(
+        repos, vlab_id=vlab_id, include_projects=include_projects
+    )
+    return ApiResponse(
+        message=f"Balance for virtual-lab{' including projects' if include_projects else ''}",
+        data=result,
+    )
+
+
+@router.get("/project/{proj_id}")
+async def get_balance_for_project(
+    repos: RepoGroupDep, proj_id: UUID
+) -> ApiResponse[ProjBalanceOut]:
+    """Return the balance for a given project."""
+    result = await balance_service.get_balance_for_project(repos, proj_id=proj_id)
+    return ApiResponse(
+        message="Balance for project",
+        data=result,
+    )

--- a/app/constants.py
+++ b/app/constants.py
@@ -6,6 +6,7 @@ from enum import auto
 from app.enum import HyphenStrEnum
 
 D0 = Decimal(0)
+DECIMAL_PLACES = 2
 
 
 class EventStatus(HyphenStrEnum):

--- a/app/repository/account.py
+++ b/app/repository/account.py
@@ -59,7 +59,7 @@ class AccountRepository(BaseRepository):
         return VlabAccount.model_validate(result)
 
     async def get_proj_account(self, proj_id: UUID, *, for_update: bool = False) -> ProjAccount:
-        """Return the project account for the given project and virtual lab ids.
+        """Return the project account for the given project id.
 
         Args:
             proj_id: project UUID.
@@ -73,23 +73,14 @@ class AccountRepository(BaseRepository):
     async def get_reservation_account(
         self, proj_id: UUID, *, for_update: bool = False
     ) -> RsvAccount:
-        """Return the reservation account for the given project and virtual lab ids.
+        """Return the reservation account for the given project id.
 
         Args:
             proj_id: project UUID.
             for_update: if True, locks the selected row against concurrent updates.
         """
-        query = sa.select(Account).where(
-            and_(
-                Account.account_type == AccountType.RSV,
-                Account.parent_id == proj_id,
-                Account.enabled == true(),
-            )
-        )
-        if for_update:
-            query = query.with_for_update()
-        result = (await self.db.execute(query)).scalar_one()
-        return RsvAccount.model_validate(result)
+        rows = await self.get_reservation_accounts(proj_ids=[proj_id], for_update=for_update)
+        return rows[0]
 
     async def get_accounts_by_proj_id(
         self, proj_id: UUID, *, for_update: set[AccountType] | None = None
@@ -107,6 +98,48 @@ class AccountRepository(BaseRepository):
         )
         sys = await self.get_system_account()
         return Accounts(sys=sys, vlab=vlab, proj=proj, rsv=rsv)
+
+    async def get_proj_accounts_for_vlab(self, vlab_id: UUID) -> list[ProjAccount]:
+        """Return all the projects for the specified virtual-lab."""
+        query = sa.select(Account).where(
+            and_(
+                Account.account_type == AccountType.PROJ,
+                Account.parent_id == vlab_id,
+                Account.enabled == true(),
+            )
+        )
+        result = (await self.db.execute(query)).scalars()
+        return [ProjAccount.model_validate(row) for row in result]
+
+    async def get_reservation_accounts(
+        self, proj_ids: list[UUID], *, for_update: bool = False
+    ) -> list[RsvAccount]:
+        """Return the reservation accounts for the given project ids.
+
+        Args:
+            proj_ids: list of project UUIDs.
+            for_update: if True, locks the selected rows against concurrent updates.
+        """
+        if not proj_ids:
+            return []
+        query = sa.select(Account).where(
+            and_(
+                Account.account_type == AccountType.RSV,
+                Account.parent_id.in_(proj_ids),
+                Account.enabled == true(),
+            )
+        )
+        if for_update:
+            query = query.with_for_update()
+        rows = (await self.db.execute(query)).scalars()
+        result = [RsvAccount.model_validate(row) for row in rows]
+        if len(result) < len(proj_ids):
+            errmsg = "No reservation account was found for some projects"
+            raise ValueError(errmsg)
+        if len(result) > len(proj_ids) or len(result) > len({rec.proj_id for rec in result}):
+            errmsg = "Multiple reservation accounts were found for some projects"
+            raise ValueError(errmsg)
+        return result
 
     async def _add_generic_account(self, **kwargs) -> Account:
         return (

--- a/app/schema/api.py
+++ b/app/schema/api.py
@@ -4,10 +4,11 @@ from decimal import Decimal
 from typing import Annotated, Any, Literal, Self
 from uuid import UUID
 
-from pydantic import AwareDatetime, BaseModel, Field, model_validator
+from pydantic import AwareDatetime, Field, model_validator
 
 from app.constants import D0, ServiceSubtype, ServiceType
 from app.errors import ApiErrorCode
+from app.schema.common import BaseModel, FormattedDecimal
 
 
 class ApiResponse[T](BaseModel):
@@ -155,3 +156,25 @@ class AddPriceOut(AddPriceIn):
     """AddPriceOut."""
 
     id: int
+
+
+class ProjBalanceOut(BaseModel):
+    """ProjBalanceOut."""
+
+    proj_id: UUID
+    balance: FormattedDecimal
+    reservation: FormattedDecimal
+
+
+class VlabBalanceOut(BaseModel):
+    """VlabBalanceOut."""
+
+    vlab_id: UUID
+    balance: FormattedDecimal
+    projects: list[ProjBalanceOut] | None = None
+
+
+class SysBalanceOut(BaseModel):
+    """SysBalanceOut."""
+
+    balance: FormattedDecimal

--- a/app/schema/common.py
+++ b/app/schema/common.py
@@ -1,12 +1,26 @@
 """Common schema."""
 
 from datetime import UTC, datetime
+from decimal import Decimal
 from typing import Annotated
 
-from pydantic import BeforeValidator, PlainSerializer, validate_call
+from pydantic import (
+    BaseModel as PydanticBaseModel,
+    BeforeValidator,
+    ConfigDict,
+    PlainSerializer,
+    validate_call,
+)
 
 from app.config import settings
+from app.constants import DECIMAL_PLACES
 from app.utils import since_unix_epoch
+
+
+class BaseModel(PydanticBaseModel):
+    """Subclass of the original BaseModel with custom configuration."""
+
+    model_config = ConfigDict(extra="forbid")
 
 
 @validate_call
@@ -26,4 +40,9 @@ RecentTimeStamp = Annotated[
     datetime,
     BeforeValidator(_convert_timestamp),
     PlainSerializer(lambda x: int(x.timestamp())),
+]
+
+FormattedDecimal = Annotated[
+    Decimal,
+    PlainSerializer(lambda x: f"{x:.{DECIMAL_PLACES}f}", return_type=str, when_used="json"),
 ]

--- a/app/schema/domain.py
+++ b/app/schema/domain.py
@@ -6,9 +6,10 @@ from decimal import Decimal
 from typing import Annotated, Any
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import ConfigDict, Field
 
 from app.constants import D0, ServiceSubtype, ServiceType
+from app.schema.common import BaseModel
 
 
 class BaseAccount(BaseModel):

--- a/app/schema/queue.py
+++ b/app/schema/queue.py
@@ -3,10 +3,10 @@
 from typing import Annotated, Literal
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from app.constants import LongrunStatus, ServiceSubtype, ServiceType
-from app.schema.common import RecentTimeStamp
+from app.schema.common import BaseModel, RecentTimeStamp
 
 
 class StorageEvent(BaseModel):

--- a/app/service/balance.py
+++ b/app/service/balance.py
@@ -1,0 +1,63 @@
+"""Balance service."""
+
+from uuid import UUID
+
+from app.errors import ensure_result
+from app.repository.group import RepositoryGroup
+from app.schema.api import ProjBalanceOut, SysBalanceOut, VlabBalanceOut
+from app.schema.domain import ProjAccount
+
+
+async def _get_balance_for_projects(
+    repos: RepositoryGroup, project_accounts: list[ProjAccount]
+) -> list[ProjBalanceOut]:
+    if not project_accounts:
+        return []
+    reservation_accounts = await repos.account.get_reservation_accounts(
+        proj_ids=[proj.id for proj in project_accounts]
+    )
+    reservation_dict = {
+        reservation.proj_id: reservation.balance for reservation in reservation_accounts
+    }
+    return [
+        ProjBalanceOut(
+            proj_id=project.id,
+            balance=project.balance,
+            reservation=reservation_dict[project.id],
+        )
+        for project in project_accounts
+    ]
+
+
+async def get_balance_for_project(repos: RepositoryGroup, proj_id: UUID) -> ProjBalanceOut:
+    """Return the balance for a given project, including the reserved amount."""
+    with ensure_result(error_message="Project not found"):
+        project_account = await repos.account.get_proj_account(proj_id=proj_id)
+    projects = await _get_balance_for_projects(repos, project_accounts=[project_account])
+    return projects[0]
+
+
+async def get_balance_for_vlab(
+    repos: RepositoryGroup, vlab_id: UUID, *, include_projects: bool = False
+) -> VlabBalanceOut:
+    """Return the balance for a given virtual-lab."""
+    with ensure_result(error_message="Virtual lab not found"):
+        vlab = await repos.account.get_vlab_account(vlab_id=vlab_id)
+    projects = None
+    if include_projects:
+        project_accounts = await repos.account.get_proj_accounts_for_vlab(vlab_id=vlab_id)
+        projects = await _get_balance_for_projects(repos, project_accounts=project_accounts)
+    return VlabBalanceOut(
+        vlab_id=vlab_id,
+        balance=vlab.balance,
+        projects=projects,
+    )
+
+
+async def get_balance_for_system(repos: RepositoryGroup) -> SysBalanceOut:
+    """Return the balance for the system account."""
+    with ensure_result(error_message="System account not found"):
+        sys = await repos.account.get_system_account()
+    return SysBalanceOut(
+        balance=sys.balance,
+    )

--- a/tests/api/test_balance.py
+++ b/tests/api/test_balance.py
@@ -1,0 +1,57 @@
+import pytest
+
+from tests.constants import PROJ_ID, PROJ_ID_2, VLAB_ID
+
+
+@pytest.mark.usefixtures("_db_account")
+async def test_get_balance_for_system(api_client):
+    response = await api_client.get("/balance/system")
+
+    assert response.json()["data"] == {"balance": "-3000.00"}
+    assert response.status_code == 200
+
+
+@pytest.mark.usefixtures("_db_account")
+async def test_get_balance_for_virtual_lab(api_client):
+    response = await api_client.get(f"/balance/virtual-lab/{VLAB_ID}")
+
+    assert response.json()["data"] == {
+        "vlab_id": VLAB_ID,
+        "balance": "2000.00",
+    }
+    assert response.status_code == 200
+
+    response = await api_client.get(
+        f"/balance/virtual-lab/{VLAB_ID}",
+        params={"include_projects": True},
+    )
+
+    assert response.json()["data"] == {
+        "vlab_id": VLAB_ID,
+        "balance": "2000.00",
+        "projects": [
+            {
+                "balance": "400.00",
+                "proj_id": PROJ_ID,
+                "reservation": "100.00",
+            },
+            {
+                "balance": "500.00",
+                "proj_id": PROJ_ID_2,
+                "reservation": "0.00",
+            },
+        ],
+    }
+    assert response.status_code == 200
+
+
+@pytest.mark.usefixtures("_db_account")
+async def test_get_balance_for_project(api_client):
+    response = await api_client.get(f"/balance/project/{PROJ_ID}")
+
+    assert response.json()["data"] == {
+        "balance": "400.00",
+        "proj_id": PROJ_ID,
+        "reservation": "100.00",
+    }
+    assert response.status_code == 200

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,14 +113,14 @@ async def _db_account(db):
                     "account_type": "SYS",
                     "parent_id": None,
                     "name": "OBP",
-                    "balance": -2000,
+                    "balance": -3000,
                 },
                 {
                     "id": VLAB_ID,
                     "account_type": "VLAB",
                     "parent_id": None,
                     "name": "Test vlab_01",
-                    "balance": 1000,
+                    "balance": 2000,
                 },
                 {
                     "id": PROJ_ID,


### PR DESCRIPTION
Initial implementation, it allows to retrieve the balance for:
- system account (for internal use/debug)
- virtual lab (with the option to include all the related projects)
- project

In case of virtual lab or project, the returned payload contains both:
- the balance amount
- the reservation amount